### PR TITLE
feat(wye support): initial integration with wye support service

### DIFF
--- a/backend/src/dataSources/WyeGamesAPI.js
+++ b/backend/src/dataSources/WyeGamesAPI.js
@@ -1,0 +1,26 @@
+const { RESTDataSource } = require("apollo-datasource-rest");
+const get = require("lodash.get");
+
+/**
+ * Builds a REST data source for Wye's support service games API
+ */
+class WyeGamesAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = process.env.WYE_SUPPORT_URL;
+  }
+
+  /**
+   * Gets information for a list of games from Wye Support Service's games endpoint
+   * @param {Array} gameIds - The game's ID to get information for
+   * @returns {Array}
+   */
+  async getGamesByGameIds(gameIds) {
+    const data = await this.get("games/", {
+      gameids: gameIds
+    });
+    return get(data, "games", []);
+  }
+}
+
+module.exports = WyeGamesAPI;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -3,6 +3,7 @@ const SteamUsersAPI = require("./dataSources/SteamUsersAPI");
 const SteamPlayerServiceAPI = require("./dataSources/SteamPlayerServiceAPI");
 const SteamNewsAPI = require("./dataSources/SteamNewsAPI");
 const SteamGamesAPI = require("./dataSources/SteamGamesAPI");
+const WyeGamesAPI = require("./dataSources/WyeGamesAPI");
 const typeDefs = require("./schema");
 const resolvers = require("./resolvers");
 
@@ -19,7 +20,8 @@ const server = new ApolloServer({
       steamUsersAPI: new SteamUsersAPI(),
       steamPlayerServiceAPI: new SteamPlayerServiceAPI(),
       steamNewsAPI: new SteamNewsAPI(),
-      steamGamesAPI: new SteamGamesAPI()
+      steamGamesAPI: new SteamGamesAPI(),
+      wyeGamesAPI: new WyeGamesAPI()
     };
   }
 });

--- a/backend/src/resolvers.js
+++ b/backend/src/resolvers.js
@@ -15,15 +15,16 @@ const resolvers = {
       { dataSources }
     ) => {
       // 1. get all unique games owned by players from Steam's player service API
-      let uniqueOwnedGames = await dataSources.steamPlayerServiceAPI.getUniqueOwnedGamesForUsersByPlayerIds(
+      const uniqueOwnedGames = await dataSources.steamPlayerServiceAPI.getUniqueOwnedGamesByPlayerIds(
         userIds
       );
 
       // 2. get details for each unique game from Wye's support service's API, applying filters, pagination, and sorting
-      const filteredUnqiueGamesDetails = await dataSources.wyeSupportServiceAPI.getGamesByGameIds(
-        uniqueOwnedGames
+      const uniqueOwnedGamesDetails = await dataSources.wyeGamesAPI.getGamesByGameIds(
+        // uniqueOwnedGames
+        "10,20,30"
       );
-      console.log(filteredUnqiueGamesDetails);
+      console.log(uniqueOwnedGamesDetails);
 
       // 3. return Recommendation for each of the results of the filtered games
       // return {

--- a/backend/src/schema.js
+++ b/backend/src/schema.js
@@ -228,7 +228,7 @@ const typeDefs = gql`
   #
   type Recommendation {
     # the recommended game's details
-    game(gameId: ID!): Game
+    game(gameId: ID!): WyeGame
     # which users own the recommended game
     ownedBy(userIds: ID!, gameId: ID!): [String]
     # which users have recently played the recommended game
@@ -244,6 +244,24 @@ const typeDefs = gql`
 
   type RecommendationEdge {
     node: Recommendation!
+  }
+
+  type WyeGame {
+    id: ID!
+    appid: String!
+    name: String!
+    developers: String!
+    publishers: String!
+    genres: String!
+    tags: String!
+    freeToPlay: Boolean!
+    onSale: Boolean!
+    discount: Int!
+    initialPrice: Int!
+    finalPrice: Int!
+    userRating: Int!
+    logoImageUrl: String!
+    heroImageUrl: String!
   }
 
   type UserPlaytime {

--- a/backend/test/__snapshots__/schema.test.js.snap
+++ b/backend/test/__snapshots__/schema.test.js.snap
@@ -1821,7 +1821,7 @@ Object {
             "kind": "NamedType",
             "name": Object {
               "kind": "Name",
-              "value": "Game",
+              "value": "WyeGame",
             },
           },
         },
@@ -2117,6 +2117,318 @@ Object {
           "kind": "FieldDefinition",
           "name": Object {
             "kind": "Name",
+            "value": "id",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "ID",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "appid",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "name",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "developers",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "publishers",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "genres",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "tags",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "freeToPlay",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Boolean",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "onSale",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Boolean",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "discount",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Int",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "initialPrice",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Int",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "finalPrice",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Int",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "userRating",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "Int",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "logoImageUrl",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
+            "value": "heroImageUrl",
+          },
+          "type": Object {
+            "kind": "NonNullType",
+            "type": Object {
+              "kind": "NamedType",
+              "name": Object {
+                "kind": "Name",
+                "value": "String",
+              },
+            },
+          },
+        },
+      ],
+      "interfaces": Array [],
+      "kind": "ObjectTypeDefinition",
+      "name": Object {
+        "kind": "Name",
+        "value": "WyeGame",
+      },
+    },
+    Object {
+      "description": undefined,
+      "directives": Array [],
+      "fields": Array [
+        Object {
+          "arguments": Array [],
+          "description": undefined,
+          "directives": Array [],
+          "kind": "FieldDefinition",
+          "name": Object {
+            "kind": "Name",
             "value": "userId",
           },
           "type": Object {
@@ -2331,7 +2643,7 @@ Object {
   ],
   "kind": "Document",
   "loc": Object {
-    "end": 5770,
+    "end": 6112,
     "start": 0,
   },
 }

--- a/backend/test/dataSources/WyeGamesAPI.test.js
+++ b/backend/test/dataSources/WyeGamesAPI.test.js
@@ -1,0 +1,49 @@
+const WyeGamesAPI = require("../../src/dataSources/WyeGamesAPI");
+
+process.env.WYE_SUPPORT_URL = "foo";
+
+describe("WyeGamesAPI", () => {
+  const gameIds = ["1", "2"];
+  let wyeGamesAPI;
+  beforeEach(() => {
+    wyeGamesAPI = new WyeGamesAPI();
+    wyeGamesAPI.get = jest.fn();
+  });
+
+  afterEach(() => {
+    wyeGamesAPI.get.mockReset();
+  });
+
+  it(`should have a baseURL property matching: ${process.env.WYE_SUPPORT_URL}`, () => {
+    expect(wyeGamesAPI.baseURL).toBe(process.env.WYE_SUPPORT_URL);
+  });
+
+  describe("getGamesByGameIds", () => {
+    it("should have a getGamesByGameIds method", () => {
+      expect(wyeGamesAPI.getGamesByGameIds).toBeDefined();
+    });
+
+    it(`should have the getGamesByGameIds method call to games/
+    with a gameids parameter matching the provided gameIds`, () => {
+      wyeGamesAPI.getGamesByGameIds(gameIds);
+      expect(wyeGamesAPI.get).toBeCalledWith("games/", {
+        gameids: gameIds
+      });
+    });
+
+    it("should have the getGamesByGameIds method return an empty array if no game data is available", async () => {
+      wyeGamesAPI.get.mockReturnValueOnce({});
+      const data = await wyeGamesAPI.getGamesByGameIds(gameIds);
+      expect(data).toEqual([]);
+    });
+
+    it("should have the getGamesByGameIds method return a games list when game data is available", async () => {
+      const mockedGamesResponse = {
+        games: [{ foo: "bar" }, { bar: "foo" }]
+      };
+      wyeGamesAPI.get.mockReturnValueOnce(mockedGamesResponse);
+      const data = await wyeGamesAPI.getGamesByGameIds(gameIds);
+      expect(data).toBe(mockedGamesResponse.games);
+    });
+  });
+});


### PR DESCRIPTION
**Background and Summary:**
Initial setup of integration with wye support service.

**Solution:**
- Added new rest data source for getting games data from Wye's support service
- Adjusted recommendations resolver to point to wye support service's data source
- Added/adjusted tests and schema definitions

relates wye